### PR TITLE
Add opt-in stream-based API to buffer reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@ mmap and similar, etc), and from CL octet vectors and streams.
 ### Still somewhat WIP, but approaching usability.
 
 Performance for vectors/pointers is somewhere between FFI to libz and chipz,
-still needs some low-level optimization of copy routines and checksums.
-Stream API is very slow, and may be replaced at some point.
+still needs some low-level optimization of copy routines and checksums. There
+are two variants of the stream API. The default is safe (will never read beyond
+the end of the compressed data, but is very slow. The second (opt-in) variant
+is much faster, but requires the length of the compressed data is known a
+priori.
 
 API isn't completely stable yet, needs some actual use to figure out
 the details.
@@ -58,7 +61,12 @@ to specify valid region within source. For FFI pointers, use
 `(with-octet-pointer (octet-pointer ffi-pointer size) ...)` to wrap a
 raw pointer + size into `octet-pointer` to pass to
 `make-octet-pointer-context`. (If you need indefinite scope pointers,
-file an issue so support that can be added to API.)
+file an issue so support that can be added to API.) For stream contexts, you
+can opt-in to buffered reads (increasing performance) by specifying
+`:buffer-size`. If you provide `:buffer-size`, the `:end` argument *must*
+correctly specify the end of the the compressed data, otherwise more data may
+be read from the stream than you intended or decompression may block waiting
+for an EOF.
 
 * step 3: decompress
 
@@ -74,8 +82,6 @@ file an issue so support that can be added to API.)
 
 
 ##### performance notes:
-
-* Streams API is currently *very* slow, and will probably be rewritten at some point.
 
 * Output in small pieces is slow:
 

--- a/io-common.lisp
+++ b/io-common.lisp
@@ -48,12 +48,22 @@
   ((octet-stream :reader octet-stream :initarg :octet-stream)
    (boxes :reader boxes :initarg :boxes)))
 
+(defclass octet-buffered-stream-context (octet-stream-context)
+  ((buffer-size :reader buffer-size :initarg :buffer-size :initform (* 8 1024))))
+
 (defun make-octet-stream-context (file-stream &key (start 0) (offset 0)
-                                                (end (file-length file-stream)))
-  (make-instance 'octet-stream-context
-                 :octet-stream file-stream
-                 :boxes (make-context-boxes
-                         :start start :offset offset :end end)))
+                                                (end (file-length file-stream))
+                                                buffer-size)
+  (if (null buffer-size)
+      (make-instance 'octet-stream-context
+                     :octet-stream file-stream
+                     :boxes (make-context-boxes
+                             :start start :offset offset :end end))
+      (make-instance 'octet-buffered-stream-context
+                     :octet-stream file-stream
+                     :boxes (make-context-boxes
+                             :start start :offset offset :end end)
+                     :buffer-size buffer-size)))
 
 ;; hack to allow storing parts of a file to use as context later. call
 ;; before using context


### PR DESCRIPTION
There is significant overhead calling the stream reading functions from nibbles. There is even more overhead when gray streams (and their associated generic function dispatch) are involved.

However, the existing approach is very safe. It will never try to read beyond the end of a compressed data stream. If it did, it may consume bytes the user did not intend or may even block forever, waiting for an EOF.

Address this by adding the :BUFFER-SIZE option to MAKE-OCTET-STREAM-CONTEXT. If provided, we buffer reads from the stream by this amount. However, the caller is responsible for providing an accurate :END, beyond which 3BZ will never read.