### PR TITLE
copy-block: Verify that output buffer is large enough

### DIFF
--- a/deflate.lisp
+++ b/deflate.lisp
@@ -535,7 +535,10 @@
               :copy-block
               (loop while (and (plusp bits-remaining)
                                (plusp bytes-to-copy))
-                    do (out-byte (bits 8))
+                    do (unless (< output-offset (length output-buffer))
+                         (setf output-overflow t)
+                         (eoo))
+                       (out-byte (bits 8))
                        (decf bytes-to-copy))
               (loop with e = (- (length output-buffer) 8)
                     while (and (> bytes-to-copy 8)
@@ -565,7 +568,10 @@
                                      (decf bytes-to-copy)))
                            (t (eoo)))))
               (loop while (plusp bytes-to-copy)
-                    do (copy-byte-or-fail)
+                    do (unless (< output-offset (length output-buffer))
+                         (setf output-overflow t)
+                         (eoo))
+                       (copy-byte-or-fail)
                        (decf bytes-to-copy))
               (next-state :block-end)
 


### PR DESCRIPTION
Should take care of [this issue](https://github.com/3b/3bz/issues/16), although it's maybe not the cleanest way to do it.